### PR TITLE
Use netcoreapp3.1 version of System.Collections

### DIFF
--- a/Mono.TextTemplating/Mono.TextTemplating.CodeCompilation/RuntimeInfo.cs
+++ b/Mono.TextTemplating/Mono.TextTemplating.CodeCompilation/RuntimeInfo.cs
@@ -157,10 +157,7 @@ namespace Mono.TextTemplating.CodeCompilation
 				return FromError (RuntimeKind.NetCore, "Could not find csc.dll in any .NET Core SDK" );
 			}
 
-			var runtimeDir = FindHighestVersionedDirectory (Path.Combine (dotnetRoot, "shared", "Microsoft.NETCore.App"), d => File.Exists (Path.Combine (d, "System.Runtime.dll")));
-			if (runtimeDir == null) {
-				return FromError (RuntimeKind.NetCore, "Could not find System.Runtime.dll in any .NET shared runtime" );
-			}
+			var runtimeDir = Path.GetDirectoryName(typeof (int).Assembly.Location);
 
 			return new RuntimeInfo (RuntimeKind.NetCore) { RuntimeDir = runtimeDir, CscPath = MakeCscPath (sdkDir) };
 		}

--- a/Mono.TextTemplating/Mono.TextTemplating/TemplateGenerator.cs
+++ b/Mono.TextTemplating/Mono.TextTemplating/TemplateGenerator.cs
@@ -79,6 +79,7 @@ namespace Mono.TextTemplating
 		
 		public TemplateGenerator ()
 		{
+			ReferencePaths.Add (Path.GetDirectoryName(typeof (int).Assembly.Location).Replace("Microsoft.NETCore.App", "Microsoft.AspNetCore.App"));
 			Refs.Add (typeof (TextTransformation).Assembly.Location);
 			Refs.Add (typeof(Uri).Assembly.Location);
 			Refs.Add (typeof (File).Assembly.Location);

--- a/dotnet-t4/ToolTemplateGenerator.cs
+++ b/dotnet-t4/ToolTemplateGenerator.cs
@@ -33,7 +33,7 @@ namespace Mono.TextTemplating
 			Refs.Add (typeof (CompilerErrorCollection).Assembly.Location);
 			Refs.Add (typeof (DescriptionAttribute).Assembly.Location);
 			Refs.Add (typeof (List<>).Assembly.Location);
-			Refs.Add ("System.Collections");
+			Refs.Add (typeof (HashSet<>).Assembly.Location);
 		}
 
 		protected override ITextTemplatingSession CreateSession () => new ToolTemplateSession (this);


### PR DESCRIPTION
When .NET 5 SDK is installed, the tool referenced the .NET 5 version, resulting in compile errors such as:

```
 error CS1069: The type name 'HashSet<>' could not be found in the namespace 'System.Collections.Generic'. This type has been forwarded to assembly 'System.Private.CoreLib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e' Consider adding a reference to that assembly.
```